### PR TITLE
Fix PHP 8.4 reference and update broken link for contribution guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -43,7 +43,7 @@ export default defineConfig({
         text: version,
         items: [
           {text: 'Changelog', link: changelog},
-          {text: 'Contribute', link: '/getting-started/contribution-guide'},
+          {text: 'Contribute', link: '/prologue/contribution-guide'},
         ]
       },
       {

--- a/docs/servers/php.md
+++ b/docs/servers/php.md
@@ -24,7 +24,7 @@ server creation in the `PHP` menu in the server page or in the [Services](./serv
 - PHP 8.1
 - PHP 8.2
 - PHP 8.3
-- PHP 8.4 (Coming Soon)
+- PHP 8.4
 
 ## Default PHP Cli
 


### PR DESCRIPTION
- Corrected the reference to PHP 8.4 in the documentation, as PHP 8.4 has already been added (replaced "PHP 8.4 (coming soon)" with "PHP 8.4").
- Fixed the broken link on the homepage pointing to `prologue/contribution-guide`, ensuring it now leads to the correct page.